### PR TITLE
implement file assoc

### DIFF
--- a/eBookReader.cfg
+++ b/eBookReader.cfg
@@ -1,0 +1,22 @@
+fileassoc={
+  app_path="/switch/eBookReader/eBookReaderSwitch.nro";
+
+  targets=(
+    {
+      file_extension=".pdf";
+      icon_path="/config/nx-hbmenu/fileassoc/eBook.jpg";
+    },
+    {
+      file_extension=".epub";
+      icon_path="/config/nx-hbmenu/fileassoc/eBook.jpg";
+    },
+    {
+      file_extension=".cbz";
+      icon_path="/config/nx-hbmenu/fileassoc/eBook.jpg";
+    },
+    {
+      file_extension=".xps";
+      icon_path="/config/nx-hbmenu/fileassoc/eBook.jpg";
+    }
+  );
+};

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -16,6 +16,7 @@ extern "C" {
     #include "common.h"
     #include "textures.h"
     #include "MenuChooser.h"
+    #include "menu_book_reader.h"
     #include "fs.h"
     #include "config.h"
 }
@@ -25,11 +26,9 @@ SDL_Window* WINDOW;
 SDL_Event EVENT;
 TTF_Font *ROBOTO_35, *ROBOTO_30, *ROBOTO_27, *ROBOTO_25, *ROBOTO_20, *ROBOTO_15;
 bool configDarkMode;
-bool run = true;
 
 void Term_Services() {
     std::cout << "Terminate Serices" << std::endl;
-    run = false;
 
     timeExit();
     TTF_CloseFont(ROBOTO_35);
@@ -127,7 +126,9 @@ void Init_Services() {
 int main(int argc, char *argv[]) {
     Init_Services();
 
-    if (run) {
+    if (argc == 2) {
+        Menu_OpenBook(argv[1]);
+    } else {
         Menu_StartChoosing();
     }
 


### PR DESCRIPTION
Implemented passing an ebook title as an argument.
With the additional config placed in "/config/nx-hbmenu/fileassoc/" you can open them directly from hbmenu.
https://switchbrew.org/wiki/Homebrew_Menu#File_Associations

You'd want to ship this with the corresponding icons in a zip.

(I removed run because it didn't do anything)