### PR TITLE
Added CI/CD pipeline with artifacts

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,7 @@ jobs:
     container: devkitpro/devkita64:latest
 
     steps:
-    - run: apt update && apt -y install libfreetype6-dev tree
+    - run: apt update && apt -y install libfreetype6-dev
     - uses: actions/checkout@v1
     - name: Update repo.
       run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,30 @@
+name: eBookReaderSwitch CI pipeline
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container: devkitpro/devkita64:latest
+
+    steps:
+    - run: apt update && apt -y install libfreetype6-dev tree
+    - uses: actions/checkout@v1
+    - name: Update repo.
+      run: |
+        git submodule update --init --recursive
+        
+    - name: Building eBookReaderSwitch
+      run: |
+        export NODEBUG=true
+        make mupdf && make -j$(nproc)
+        
+    - uses: actions/upload-artifact@master
+      with:
+        name: eBookReaderSwitch
+        path: eBookReaderSwitch.nro

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,12 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions #-DDEBUG=1 -DEXPERIMENTAL=1
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
+nodebug = ${NODEBUG}
+ifdef nodebug
+LIBS    :=  -lstdc++fs -lSDL2_ttf -lSDL2_image -lpng -ljpeg `sdl2-config --libs` -lfreetype -lwebp -lz -lbz2 -lconfig -lnx -lmupdf -lmupdf-third #-lmupdf_core -lmupdf_thirdparty
+else
 LIBS    :=  -lstdc++fs -lSDL2_ttf -lSDL2_image -lpng -ljpeg `sdl2-config --libs` -lfreetype -lwebp -lz -lbz2 -ltwili -lconfig -lnx -lmupdf -lmupdf-third #-lmupdf_core -lmupdf_thirdparty
+endif
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,13 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions #-DDEBUG=1 -DEXPERIMENTAL=1
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-nodebug = ${NODEBUG}
-ifdef nodebug
-LIBS    :=  -lstdc++fs -lSDL2_ttf -lSDL2_image -lpng -ljpeg `sdl2-config --libs` -lfreetype -lwebp -lz -lbz2 -lconfig -lnx -lmupdf -lmupdf-third #-lmupdf_core -lmupdf_thirdparty
-else
-LIBS    :=  -lstdc++fs -lSDL2_ttf -lSDL2_image -lpng -ljpeg `sdl2-config --libs` -lfreetype -lwebp -lz -lbz2 -ltwili -lconfig -lnx -lmupdf -lmupdf-third #-lmupdf_core -lmupdf_thirdparty
+LIBS_REAL = stdc++fs SDL2_ttf SDL2_image png jpeg freetype webp z bz2 config nx mupdf mupdf-third
+## LIBS_REAL += mupdf_core mupdf_thirdparty
+
+ifeq (,$(NODEBUG))
+LIBS_REAL += twili
 endif
+LIBS = $(addprefix -l,$(LIBS_REAL)) $(shell sdl2-config --libs)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing


### PR DESCRIPTION
Added a CI/CD pipeline with artifacts, now after each commit you can download a binary file for tests.
WARNING: The twili module is excluded for this pipeline.

Visit https://github.com/Disinterpreter/eBookReaderSwitch/actions/runs/1084880507 for checking the pipeline